### PR TITLE
Add GUI tests to remove video batch

### DIFF
--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -376,10 +376,6 @@ class GenericTableView(QtWidgets.QTableView):
         """
         idx = self.currentIndex()
 
-        if self.multiple_selection:
-            idx_temp = set([x.row() for x in self.selectedIndexes()])
-            self.state[f"selected_batch_{self.row_name}"] = idx_temp
-
         if not idx.isValid():
             return None
         return self.model().original_items[idx.row()]

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -192,7 +192,7 @@ class VideosDock(DockWidget):
         self.add_button(hb, "Toggle Grayscale", main_window.commands.toggleGrayscale)
         self.add_button(hb, "Show Video", self.table.activateSelected)
         self.add_button(hb, "Add Videos", main_window.commands.addVideo)
-        self.add_button(hb, "Remove Video", main_window.commands.removeVideo)
+        self.add_button(hb, "Remove Video", self.remove_video)
         hbw = QWidget()
         hbw.setLayout(hb)
         return hbw
@@ -203,6 +203,13 @@ class VideosDock(DockWidget):
 
         video_edit_and_nav_buttons = self.create_video_edit_and_nav_buttons()
         self.wgt_layout.addWidget(video_edit_and_nav_buttons)
+
+    def remove_video(self):
+        """Remove videos from the table."""
+
+        video_idxs = set([qmodel_idx.row() for qmodel_idx in self.table.selectedIndexes()])
+        videos_to_remove = [self.table.model().original_items[idx] for idx in video_idxs]
+        self.main_window.commands.removeVideo(videos_to_remove)
 
 
 class SkeletonDock(DockWidget):

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from sleap import Labels, Video
 from sleap.gui.app import MainWindow
 from sleap.gui.widgets.docks import (
     InstancesDock,
@@ -11,14 +12,43 @@ from sleap.gui.widgets.docks import (
 )
 
 
-def test_videos_dock(qtbot):
+def test_videos_dock(qtbot, centered_pair_predictions: Labels,
+    small_robot_mp4_vid: Video,
+    centered_pair_vid: Video,
+    small_robot_3_frame_vid: Video,):
     """Test the `DockWidget` class."""
+    
+    # Add some extra videos to the labels
+    labels = centered_pair_predictions
+    labels.add_video(small_robot_mp4_vid)
+    labels.add_video(centered_pair_vid)
+    labels.add_video(small_robot_3_frame_vid)
+    assert len(labels.videos) == 4
+
+    # Create the dock
     main_window = MainWindow()
+    main_window.labels = labels
+    video_state = labels.videos[-1]
+    main_window.state["video"] = video_state
     dock = VideosDock(main_window)
 
+    # Test that the dock was created correctly
     assert dock.name == "Videos"
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
+
+    # Test that videos can be removed
+
+    # No videos selected, should remove the state video
+    dock.main_window._buttons["remove video"].click()
+    assert len(labels.videos) == 3
+    assert video_state not in labels.videos
+    assert main_window.state["video"] == labels.videos[-1]
+
+    # TODO(LM): Select the first video, should remove that one and update state
+    
+    # TODO(LM): Select the last two videos, should remove those two and update state
+
 
 
 def test_skeleton_dock(qtbot):
@@ -51,5 +81,6 @@ def test_instances_dock(qtbot):
     assert dock.wgt_layout is dock.widget().layout()
 
 
+# TODO(LM): Remove test code before merging
 if __name__ == "__main__":
-    pytest.main([f"{__file__}::test_instances_dock"])
+    pytest.main([f"{__file__}::test_videos_dock"])


### PR DESCRIPTION
### Description
This PR aims to add some GUI tests for the remove videos in batch command, but also toys with the idea of passing in the videos to remove directly instead of setting the [GUI state](https://refactoring.guru/design-patterns/state) (which should ideally be reserved for variables that elicit a callback function when changed). 

While some of the GUI tests are already laid out, there are a few TODOs, namely in `tests/gui/widgets/test_docks.py`

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
